### PR TITLE
Add support for machines other than Raspberry Pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+output.csv
 venv/

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import subprocess
 import csv
 import os
 
-RUNTIME = 10  # runtime of each cycle in seconds, must be multiple of 10
+RUNTIME = 600  # runtime of each cycle in seconds, must be multiple of 10
 
 if not RUNTIME % 10 == 0:
     raise ValueError("Runtime must be a multiple of 10!")

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import subprocess
 import csv
 import os
 
-RUNTIME = 600  # runtime of each cycle in seconds, must be multiple of 10
+RUNTIME = 10  # runtime of each cycle in seconds, must be multiple of 10
 
 if not RUNTIME % 10 == 0:
     raise ValueError("Runtime must be a multiple of 10!")
@@ -46,6 +46,9 @@ try:
     print("logging cooldown")
     do_logging()
 except KeyboardInterrupt:
-    with open("output.csv", "w") as f:
-        writer = csv.writer(f)
-        writer.writerows(values)
+    pass
+
+with open("output.csv", "w") as f:
+    writer = csv.writer(f)
+    writer.writerows(values)
+

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from time import time, sleep
 import psutil
 import subprocess
 import csv
-import os
 
 RUNTIME = 600  # runtime of each cycle in seconds, must be multiple of 10
 

--- a/main.py
+++ b/main.py
@@ -14,8 +14,10 @@ if not RUNTIME % 10 == 0:
 values = []
 
 def get_cpu_temp():
-    raw = psutil.sensors_temperatures()['k10temp']
-    return raw[1].current
+    raw = psutil.sensors_temperatures()
+    tl = list(raw.items())
+    temp = tl[0][1][0].current
+    return temp
 
 def do_logging():
     for _ in range(RUNTIME//10):
@@ -26,24 +28,24 @@ def do_logging():
         values.append([ctime, temperature, cpu_speed])
         sleep(10)
 
+try:
+    print("sleeping to decrease CPU speed after setup")
+    sleep(10)
 
-print("sleeping to decrease CPU speed after setup")
-sleep(10)
-
-print("logging idle")
-do_logging()
+    print("logging idle")
+    do_logging()
 
 
-stress = subprocess.Popen(["stress", "-c", "4", "-m", "1", "-t", str(RUNTIME)])
+    stress = subprocess.Popen(["stress", "-c", "4", "-m", "1", "-t", str(RUNTIME)])
 
-print("logging stress")
-do_logging()
+    print("logging stress")
+    do_logging()
 
-stress.poll()
+    stress.poll()
 
-print("logging cooldown")
-do_logging()
-
-with open("output.csv", "w") as f:
-    writer = csv.writer(f)
-    writer.writerows(values)
+    print("logging cooldown")
+    do_logging()
+except KeyboardInterrupt:
+    with open("output.csv", "w") as f:
+        writer = csv.writer(f)
+        writer.writerows(values)

--- a/main.py
+++ b/main.py
@@ -1,23 +1,25 @@
 # coding=utf-8
 # https://projects.raspberrypi.org/en/projects/temperature-log/
-from gpiozero import CPUTemperature
 from time import time, sleep
 import psutil
 import subprocess
 import csv
+import os
 
 RUNTIME = 600  # runtime of each cycle in seconds, must be multiple of 10
 
 if not RUNTIME % 10 == 0:
     raise ValueError("Runtime must be a multiple of 10!")
 
-temp = CPUTemperature()
 values = []
 
+def get_cpu_temp():
+    raw = psutil.sensors_temperatures()['k10temp']
+    return raw[1].current
 
 def do_logging():
     for _ in range(RUNTIME//10):
-        temperature = temp.temperature
+        temperature = get_cpu_temp()
         cpu_speed = psutil.cpu_freq()[0]
         ctime = round(time())
         print(f"{ctime}: {cpu_speed}MHz: {temperature} deg C")

--- a/process_csv.py
+++ b/process_csv.py
@@ -14,7 +14,7 @@ print(x)
 
 fig = plt.figure()
 ax = fig.add_subplot(1, 1, 1)
-plt.title("ARM Core Temperature and Speed vs Time")
+plt.title("Core Temperature and Speed vs Time")
 ax.plot(x, y0, "r")
 ax.plot(x, y1, "b")
 loc = plticker.MaxNLocator(nbins=5)

--- a/process_csv.py
+++ b/process_csv.py
@@ -9,7 +9,7 @@ with open("output.csv") as f:
 
 x = [i[0] for i in data]
 y0 = [float(i[1]) for i in data]
-y1 = [int(i[2])/100 for i in data]
+y1 = [float(i[2])/100 for i in data]
 print(x)
 
 fig = plt.figure()


### PR DESCRIPTION
This PR aims to add support for other machines, not only the Raspberry Pi.

Changelog:

1.  Change CPU temperature reading from `gpiozero` to `psutil`.
2.  Change data processing to account for floats instead of integers as CPU speeds.
3.  Reword some ARM-specific language.
4.  Allow for KeyboardInterrupts to be used to stop the test, and still write the data to `output.csv` (not really necessary, just a quality of life thing).

These changes were made for, and tested on: nVidia Jetson Nano (aarch64), Raspberry Pi 2B+ (armhf), and my custom PC/server (amd64).